### PR TITLE
Add ability to use wireguard wg utility in sing-box containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ LABEL maintainer="nekohasekai <contact-git@sekai.icu>"
 RUN set -ex \
     && apk upgrade \
     && apk add bash tzdata ca-certificates nftables \
+    && apk add wireguard-tools \
     && rm -rf /var/cache/apk/*
 COPY --from=builder /go/bin/sing-box /usr/local/bin/sing-box
 ENTRYPOINT ["sing-box"]


### PR DESCRIPTION
## Summary
This allows us to do things like `wg set` in the container. Ultimately phost can use docker exec and manage peers.

From the phost we can run code like below
```
func (s *WireGuardServer) AddPeer(ctx context.Context, req *apipb.AddPeerRequest) (*apipb.WireGuardResponse, error) {
	cmd := []string{"wg", "set", req.WireguardInterface, "peer", req.PeerPublicKey, "allowed-ips", req.AllowedIps}
	msg, err := execInContainer(ctx, req.WireguardHostMachine, cmd)
	if err != nil {
		return nil, err
	}
	return &apipb.WireGuardResponse{Message: msg}, nil
}
```